### PR TITLE
Fix for #5

### DIFF
--- a/src/LumenGenerator/Console/KeyGenerateCommand.php
+++ b/src/LumenGenerator/Console/KeyGenerateCommand.php
@@ -3,9 +3,12 @@
 namespace Flipbox\LumenGenerator\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 
 class KeyGenerateCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *


### PR DESCRIPTION
`php artisan key:generate` fails because `confirmToProceed()` is called and the `ConfirmableTrait` wasn't imported 