### PR TITLE
remove: remove `use Illuminate\Console\GeneratorCommand;`

### DIFF
--- a/src/LumenGenerator/Console/TestMakeCommand.php
+++ b/src/LumenGenerator/Console/TestMakeCommand.php
@@ -2,8 +2,6 @@
 
 namespace Flipbox\LumenGenerator\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
 class TestMakeCommand extends GeneratorCommand
 {
     /**


### PR DESCRIPTION
Illuminate\Console\GeneratorCommand conflict with Flipbox\LumenGenerator\Console\GeneratorCommand in PHP 7.1,
and is unecessary.