### PR TITLE
issue#15

### DIFF
--- a/src/LumenGenerator/Console/TestMakeCommand.php
+++ b/src/LumenGenerator/Console/TestMakeCommand.php
@@ -2,8 +2,6 @@
 
 namespace Flipbox\LumenGenerator\Console;
 
-use Illuminate\Console\GeneratorCommand;
-
 class TestMakeCommand extends GeneratorCommand
 {
     /**


### PR DESCRIPTION
fix issue#15

fix this fail : 
`  [Symfony\Component\Debug\Exception\FatalErrorException]
  Cannot use Illuminate\Console\GeneratorCommand as GeneratorCommand because the name is already in use
`