### PR TITLE
fix: fix Lumen v5.5 compatibility

### DIFF
--- a/src/LumenGenerator/Console/ClearCompiledCommand.php
+++ b/src/LumenGenerator/Console/ClearCompiledCommand.php
@@ -23,7 +23,7 @@ class ClearCompiledCommand extends Command
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         $compiledPath = base_path('bootstrap/cache/compiled.php');
 

--- a/src/LumenGenerator/Console/GeneratorCommand.php
+++ b/src/LumenGenerator/Console/GeneratorCommand.php
@@ -47,7 +47,7 @@ abstract class GeneratorCommand extends Command
      *
      * @return bool|null
      */
-    public function fire()
+    public function handle()
     {
         $name = $this->parseName($this->getNameInput());
 

--- a/src/LumenGenerator/Console/KeyGenerateCommand.php
+++ b/src/LumenGenerator/Console/KeyGenerateCommand.php
@@ -30,7 +30,7 @@ class KeyGenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = $this->generateRandomKey();
 

--- a/src/LumenGenerator/Console/ListenerMakeCommand.php
+++ b/src/LumenGenerator/Console/ListenerMakeCommand.php
@@ -31,13 +31,13 @@ class ListenerMakeCommand extends GeneratorCommand
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         if (!$this->option('event')) {
             return $this->error('Missing required option: --event');
         }
 
-        parent::fire();
+        parent::handle();
     }
 
     /**

--- a/src/LumenGenerator/Console/ModelMakeCommand.php
+++ b/src/LumenGenerator/Console/ModelMakeCommand.php
@@ -31,9 +31,9 @@ class ModelMakeCommand extends GeneratorCommand
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
-        if (parent::fire() !== false) {
+        if (parent::handle() !== false) {
             if ($this->option('migration')) {
                 $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
 

--- a/src/LumenGenerator/Console/OptimizeCommand.php
+++ b/src/LumenGenerator/Console/OptimizeCommand.php
@@ -46,7 +46,7 @@ class OptimizeCommand extends Command
     /**
      * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         $this->info('Generating optimized class loader');
 

--- a/src/LumenGenerator/Console/RouteListCommand.php
+++ b/src/LumenGenerator/Console/RouteListCommand.php
@@ -22,13 +22,24 @@ class RouteListCommand extends Command
     protected $description = 'Display all registered routes.';
 
     /**
+     * Get the router.
+     *
+     * @return \Laravel\Lumen\Routing\Router
+     */
+    protected function getRouter()
+    {
+        return isset($this->laravel->router) ? $this->laravel->router : $this->laravel;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
-        $routeCollection = $this->laravel->getRoutes();
+        $router = $this->getRouter();
+        $routeCollection = $router->getRoutes();
         $rows = array();
 
         foreach ($routeCollection as $route) {

--- a/src/LumenGenerator/Console/SeederMakeCommand.php
+++ b/src/LumenGenerator/Console/SeederMakeCommand.php
@@ -54,9 +54,9 @@ class SeederMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
-        parent::fire();
+        parent::handle();
 
         $this->composer->dumpAutoloads();
     }

--- a/src/LumenGenerator/Console/ServeCommand.php
+++ b/src/LumenGenerator/Console/ServeCommand.php
@@ -29,7 +29,7 @@ class ServeCommand extends Command
      *
      * @throws \Exception
      */
-    public function fire()
+    public function handle()
     {
         chdir($this->laravel->basePath('public'));
 


### PR DESCRIPTION
* fix `fire` method Lumen v5.5 compatibility

According to https://laravel.com/docs/5.5/upgrade, the `fire` method has been changed to `handle` in Lumen v5.5,
which break `lumen-generator` in Lumen v5.5.

In Laravel v5.4 Illuminate/Console/Command.php Line 180, there is `handle` method support:

```php
$method = method_exists($this, 'handle') ? 'handle' : 'fire';
```

So it just need to change `fire` method name to `handle`.

* fix `artisan route:list` Lumen v5.5 compatibility

In Lumen v5.5 router methods is not directly attached to Application. To get `Router` object, we need to use `$app->router`.

This fix add Lumen v5.5 compatibility support, and do not break Lumen v5.4 support.