### PR TITLE
Update test.stub

### DIFF
--- a/src/LumenGenerator/Console/stubs/test.stub
+++ b/src/LumenGenerator/Console/stubs/test.stub
@@ -2,8 +2,8 @@
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Lumen\Testing\DatabaseMigrations;
+use Laravel\Lumen\Testing\DatabaseTransactions;
 
 class DummyClass extends TestCase
 {


### PR DESCRIPTION
fix import use clause namespace for DatabaseMigrations and DatabaseTransactions. They reside at Laravel\Lumen\Testing (on package laravel/lumen-framework). While Illuminate\Foundation namespace is on package laravel/framework.