### PR TITLE
Add --markdown option to make:mail generator

### DIFF
--- a/src/LumenGenerator/Console/MailMakeCommand.php
+++ b/src/LumenGenerator/Console/MailMakeCommand.php
@@ -2,6 +2,8 @@
 
 namespace Flipbox\LumenGenerator\Console;
 
+use Symfony\Component\Console\Input\InputOption;
+
 class MailMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/LumenGenerator/Console/MailMakeCommand.php
+++ b/src/LumenGenerator/Console/MailMakeCommand.php
@@ -24,6 +24,55 @@ class MailMakeCommand extends GeneratorCommand
      * @var string
      */
     protected $type = 'Mail';
+    
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return;
+        }
+        
+        if ($this->option('markdown')) {
+            $this->writeMarkdownTemplate();
+        }
+    }
+    
+    /**
+     * Write the Markdown template for the mailable.
+     *
+     * @return void
+     */
+    protected function writeMarkdownTemplate()
+    {
+        $path = resource_path('views/'.str_replace('.', '/', $this->option('markdown'))).'.blade.php';
+        
+        if (! $this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0755, true);
+        }
+        
+        $this->files->put($path, file_get_contents(__DIR__.'/stubs/markdown.stub'));
+    }
+    
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $class = parent::buildClass($name);
+        
+        if ($this->option('markdown')) {
+            $class = str_replace('DummyView', $this->option('markdown'), $class);
+        }
+        
+        return $class;
+    }
 
     /**
      * Get the stub file for the generator.
@@ -32,7 +81,9 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/mail.stub';
+        return $this->option('markdown')
+                        ? __DIR__.'/stubs/markdown-mail.stub'
+                        : __DIR__.'/stubs/mail.stub';
     }
 
     /**
@@ -44,5 +95,19 @@ class MailMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Mail';
+    }
+    
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists.'],
+            
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable.'],
+        ];
     }
 }

--- a/src/LumenGenerator/Console/stubs/markdown-mail.stub
+++ b/src/LumenGenerator/Console/stubs/markdown-mail.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->markdown('DummyView');
+    }
+}

--- a/src/LumenGenerator/Console/stubs/markdown.stub
+++ b/src/LumenGenerator/Console/stubs/markdown.stub
@@ -1,0 +1,12 @@
+@component('mail::message')
+# Introduction
+
+The body of your message.
+
+@component('mail::button', ['url' => ''])
+Button Text
+@endcomponent
+
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent


### PR DESCRIPTION
Adds the necessary stubs and methods to support Markdown mailables in Lumen. Don't forget to `composer require illuminate/mail` tho!

Fixes #26