### PR TITLE
Add suggested package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "psr-4": {
             "Flipbox\\LumenGenerator\\": "src/LumenGenerator/"
         }
+    },
+    "suggest": {
+        "illuminate/mail": "Needed to run Mailable generator"
     }
 }


### PR DESCRIPTION
Helpful in case users intend to generate Mailables as Lumen doesn't include `illuminate/mail` by default.