### PR TITLE
Support for include

### DIFF
--- a/src/LumenGenerator/Console/TinkerCommand.php
+++ b/src/LumenGenerator/Console/TinkerCommand.php
@@ -35,7 +35,7 @@ class TinkerCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'tinker';
+    protected $signature = 'tinker {include?}';
 
     /**
      * The console command description.
@@ -68,6 +68,7 @@ class TinkerCommand extends Command
         );
 
         $shell = new Shell($config);
+        $shell->setIncludes([$this->argument('include')]);
 
         $shell->run();
     }


### PR DESCRIPTION
Added support to pass an `include` script as first argument to the tinker command. Allows usage like this

`php artisan tinker path/to/tinker/script.php` 

script.php
```
$environment = app()->environment();
$output = new Symfony\Component\Console\Output\ConsoleOutput();
$output->writeln("<info>Hello the app environment is `{$environment}`</info>");
$output->writeln("<comment>Did something</comment>");
$output->writeln("<error>Did something bad</error>");
```