### PR TITLE
Clean up if conditions

### DIFF
--- a/src/LumenGenerator/Console/JobMakeCommand.php
+++ b/src/LumenGenerator/Console/JobMakeCommand.php
@@ -36,9 +36,9 @@ class JobMakeCommand extends GeneratorCommand
     {
         if ($this->option('sync')) {
             return __DIR__.'/stubs/job.stub';
-        } else {
-            return __DIR__.'/stubs/job-queued.stub';
         }
+
+        return __DIR__.'/stubs/job-queued.stub';
     }
 
     /**

--- a/src/LumenGenerator/Console/ListenerMakeCommand.php
+++ b/src/LumenGenerator/Console/ListenerMakeCommand.php
@@ -81,9 +81,9 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         if ($this->option('queued')) {
             return __DIR__.'/stubs/listener-queued.stub';
-        } else {
-            return __DIR__.'/stubs/listener.stub';
         }
+
+        return __DIR__.'/stubs/listener.stub';
     }
 
     /**

--- a/src/LumenGenerator/Console/ModelMakeCommand.php
+++ b/src/LumenGenerator/Console/ModelMakeCommand.php
@@ -33,12 +33,10 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        if (parent::handle() !== false) {
-            if ($this->option('migration')) {
-                $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
+        if ((parent::handle() !== false) && $this->option('migration')) {
+            $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
 
-                $this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
-            }
+            $this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
         }
     }
 

--- a/src/LumenGenerator/Console/ResourceMakeCommand.php
+++ b/src/LumenGenerator/Console/ResourceMakeCommand.php
@@ -49,9 +49,11 @@ class ResourceMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->collection()
-                    ? __DIR__.'/stubs/resource-collection.stub'
-                    : __DIR__.'/stubs/resource.stub';
+        if($this->collection()) {
+            return __DIR__.'/stubs/resource-collection.stub';
+        }
+
+        return __DIR__.'/stubs/resource.stub';
     }
 
     /**
@@ -61,8 +63,8 @@ class ResourceMakeCommand extends GeneratorCommand
      */
     protected function collection()
     {
-        return $this->option('collection') ||
-               Str::endsWith($this->argument('name'), 'Collection');
+        return $this->option('collection')
+            || Str::endsWith($this->argument('name'), 'Collection');
     }
 
     /**

--- a/src/LumenGenerator/Console/RouteListCommand.php
+++ b/src/LumenGenerator/Console/RouteListCommand.php
@@ -28,7 +28,11 @@ class RouteListCommand extends Command
      */
     protected function getRouter()
     {
-        return isset($this->laravel->router) ? $this->laravel->router : $this->laravel;
+        if(isset($this->laravel->router)) {
+            return $this->laravel->router;
+        }
+
+        return $this->laravel;
     }
 
     /**
@@ -80,7 +84,11 @@ class RouteListCommand extends Command
      */
     protected function getNamedRoute(array $action)
     {
-        return (!isset($action['as'])) ? "" : $action['as'];
+        if(!isset($action['as'])) {
+            return '';
+        }
+
+        return $action['as'];
     }
 
     /**
@@ -93,7 +101,7 @@ class RouteListCommand extends Command
             return 'None';
         }
 
-        return current(explode("@", $action['uses']));
+        return current(explode('@', $action['uses']));
     }
 
     /**
@@ -102,17 +110,17 @@ class RouteListCommand extends Command
      */
     protected function getAction(array $action)
     {
-        if (!empty($action['uses'])) {
-            $data = $action['uses'];
-
-            if (($pos = strpos($data, "@")) !== false) {
-                return substr($data, $pos + 1);
-            } else {
-                return "METHOD NOT FOUND";
-            }
-        } else {
+        if (empty($action['uses'])) {
             return 'Closure';
         }
+
+        $data = $action['uses'];
+
+        if(($pos = strpos($data, '@')) !== false) {
+            return substr($data, $pos + 1);
+        }
+
+        return 'METHOD NOT FOUND';
     }
 
     /**
@@ -121,6 +129,14 @@ class RouteListCommand extends Command
      */
     protected function getMiddleware(array $action)
     {
-        return (isset($action['middleware'])) ? (is_array($action['middleware'])) ? join(", ", $action['middleware']) : $action['middleware'] : '';
+        if(!isset($action['middleware'])) {
+            return '';
+        }
+
+        if(is_array($action['middleware'])) {
+            return implode(', ', $action['middleware']);
+        }
+
+        return $action['middleware'];
     }
 }


### PR DESCRIPTION
This PR cleans up some of the `if` cconditions used in the commands. Instead of using `else` everywhere, we can also just return early (in the first "branch" of the `if` statement), and remove the `else` statement entirely.