### PR TITLE
Add viewAny method to policy generator

### DIFF
--- a/src/LumenGenerator/Console/stubs/policy.stub
+++ b/src/LumenGenerator/Console/stubs/policy.stub
@@ -11,6 +11,17 @@ class DummyClass
     use HandlesAuthorization;
 
     /**
+     * Determine whether the user can view any dummyPluralModelName.
+     *
+     * @param  DummyRootNamespaceUser  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
      * Determine whether the user can view the dummyModelName.
      *
      * @param  DummyRootNamespaceUser  $user


### PR DESCRIPTION
According to the Laravel 6 upgrade guide [https://laravel.com/docs/6.x/upgrade#authorized-resources](url) it would be necessary to add "viewAny" method to the policy generator. This won't brake any backward compatibility when using the generator with Laravel ^5.4 as described in package.json.