### PR TITLE
Support class preloader v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "illuminate/support": "^5.4|^6.0",
         "symfony/var-dumper": "^3.1|^4.1|^4.2|^4.3",
         "psy/psysh": "0.8.*|0.9.*",
-        "classpreloader/classpreloader": "^3.0"
+        "classpreloader/classpreloader": "^3.0|^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/LumenGenerator/Console/OptimizeCommand.php
+++ b/src/LumenGenerator/Console/OptimizeCommand.php
@@ -60,7 +60,11 @@ class OptimizeCommand extends Command
         if ($this->option('force') || !env('APP_DEBUG')) {
             $this->info('Compiling common classes');
 
-            $this->compileClasses();
+            if (class_exists(Factory::class)) {
+                $this->compileClassesV3();
+            } else {
+                $this->compileClassesV4();
+            }
         } else {
             $this->call('clear-compiled');
         }
@@ -79,7 +83,7 @@ class OptimizeCommand extends Command
             foreach ($this->getClassFiles() as $file) {
                 try {
                     fwrite($handle, $preloader->getCode($file, false)."\n");
-                } catch (V4VisitorException $e) {
+                } catch (V3VisitorException $e) {
                     //
                 }
             }

--- a/src/LumenGenerator/Console/OptimizeCommand.php
+++ b/src/LumenGenerator/Console/OptimizeCommand.php
@@ -5,8 +5,11 @@ namespace Flipbox\LumenGenerator\Console;
 use ClassPreloader\Factory;
 use Illuminate\Console\Command;
 use Illuminate\Support\Composer;
+use ClassPreloader\OutputWriter;
+use ClassPreloader\CodeGenerator;
 use Symfony\Component\Console\Input\InputOption;
-use ClassPreloader\Exceptions\VisitorExceptionInterface;
+use ClassPreloader\Exception\VisitorExceptionInterface as V4VisitorException;
+use ClassPreloader\Exceptions\VisitorExceptionInterface as V3VisitorException;
 
 class OptimizeCommand extends Command
 {
@@ -66,21 +69,48 @@ class OptimizeCommand extends Command
     /**
      * Generate the compiled class file.
      */
-    protected function compileClasses()
+    protected function compileClassesV3()
     {
         $preloader = (new Factory())->create(['skip' => true]);
 
         $handle = $preloader->prepareOutput(base_path('bootstrap/cache/compiled.php'));
 
-        foreach ($this->getClassFiles() as $file) {
-            try {
-                fwrite($handle, $preloader->getCode($file, false)."\n");
-            } catch (VisitorExceptionInterface $e) {
-                //
+        try {
+            foreach ($this->getClassFiles() as $file) {
+                try {
+                    fwrite($handle, $preloader->getCode($file, false)."\n");
+                } catch (V4VisitorException $e) {
+                    //
+                }
             }
+        } finally {
+            fclose($handle);
         }
+    }
 
-        fclose($handle);
+    /**
+     * Generate the compiled class file.
+     */
+    protected function compileClassesV4()
+    {
+        $codeGen = CodeGenerator::create(['skip' => true]);
+
+        $handle = OutputWriter::openOutputFile(base_path('bootstrap/cache/compiled.php'));
+
+        try {
+            OutputWriter::writeOpeningTag($handle, $strictTypes);
+
+            foreach ($this->getClassFiles() as $file) {
+                try {
+                    $code = $codeGen->getCode($file, false);
+                    OutputWriter::writeFileContent($handle, $code."\n");
+                } catch (V4VisitorException $e) {
+                    //
+                }
+            }
+        } finally {
+            OutputWriter::closeHandle($handle);
+        }
     }
 
     /**


### PR DESCRIPTION
Adds support for Class Preloader 4, along side version 3. This is so people can not have dependency conflicts with PHP Parser 4 (Class Preloader 3 depended on PHP Parser 1, 2, or 3). Class Preloader 4 also supports all the new syntax in PHP 7.3 and 7.4. Class Preloader 3 supported all the new syntax up to PHP 7.2 only.

---

// cc @SidIcarus