### PR TITLE
fix:#86 resource.stub should extend JsonResource? 

### DIFF
--- a/src/LumenGenerator/Console/stubs/resource.stub
+++ b/src/LumenGenerator/Console/stubs/resource.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class DummyClass extends Resource
+class DummyClass extends JsonResource
 {
     /**
      * Transform the resource into an array.


### PR DESCRIPTION
resource.stub
- changed _extends Resource_ to _extends JsonResource_