### PR TITLE
Form request command added for anik/form-request package

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ make:model           Create a new Eloquent model class
 make:notification    Create a new notification class
 make:policy          Create a new policy class
 make:provider        Create a new service provider class
+make:request         Create a new form request class
 make:seeder          Create a new seeder class
 make:test            Create a new test class
 

--- a/src/LumenGenerator/Console/RequestMakeCommand.php
+++ b/src/LumenGenerator/Console/RequestMakeCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Flipbox\LumenGenerator\Console;
+
+class RequestMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:request';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new form request class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Request';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/request.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Requests';
+    }
+}

--- a/src/LumenGenerator/Console/stubs/request.stub
+++ b/src/LumenGenerator/Console/stubs/request.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace DummyNamespace;
+
+use Anik\Form\FormRequest;
+
+class DummyClass extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    protected function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/LumenGenerator/LumenGeneratorServiceProvider.php
+++ b/src/LumenGenerator/LumenGeneratorServiceProvider.php
@@ -38,6 +38,7 @@ class LumenGeneratorServiceProvider extends ServiceProvider
         'ControllerMake' => 'command.controller.make',
         'EventMake' => 'command.event.make',
         'ExceptionMake' => 'command.exception.make',
+        'RequestMake' => 'command.request.make',
         'JobMake' => 'command.job.make',
         'ListenerMake' => 'command.listener.make',
         'MailMake' => 'command.mail.make',
@@ -219,6 +220,16 @@ class LumenGeneratorServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.middleware.make', function ($app) {
             return new Console\MiddlewareMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     */
+    protected function registerRequestMakeCommand()
+    {
+        $this->app->singleton('command.request.make', function ($app) {
+            return new Console\RequestMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
I have a package similar to Laravel's form request which I use with Lumen. [Package anik/form-request](https://packagist.org/packages/anik/form-request)
As I use this package and that form request package, so I thought if you could merge this PR.