### PR TITLE
Set the correct model directory for the make:model command in Lumen 8

### DIFF
--- a/src/LumenGenerator/Console/ModelMakeCommand.php
+++ b/src/LumenGenerator/Console/ModelMakeCommand.php
@@ -153,7 +153,9 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace;
+        return is_dir($this->laravel->basePath('app/Models'))
+            ? $rootNamespace.'\\Models'
+            : $rootNamespace;
     }
 
     /**


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
It fixes the issue https://github.com/flipboxstudio/lumen-generator/issues/96

How should this be manually tested?
-----------------------------------
1. Add the fork to your `composer.json` file:

```json
    "require": {
        "php": "^7.3|^8.0",
        "laravel/lumen-framework": "^8.0",
        "flipbox/lumen-generator": "dev-fix_model_creation_path"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/jorgemudry/lumen-generator"
        }
    ]
```

2. Install the package:

```bash
$ composer update flipbox/lumen-generator;
```

3. Use the `make:model` command:

```bash
$ php artisan make:model Account
```

4. You should end up with an `Account.php` model in your `app/Models` directory looking like this:

```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;

class Account extends Model
{
    //
}

```
Any background context you want to provide?
-------------------------------------------
With the new version 8 of Lumen (and Laravel) models get created inside of the `app/Models` directory.
 
Any extra info?
---------------
![mother](https://mrwgifs.com/wp-content/uploads/2013/04/Emilia-Clarke-Cute-Smile-Laugh-Reaction-Gif.gif)