### PR TITLE
Add schema:dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ $app->register(Flipbox\LumenGenerator\LumenGeneratorServiceProvider::class);
 ```
 key:generate         Set the application key
 
+make:cast            Create a new custom Eloquent cast class
 make:channel         Create a new channel class
 make:command         Create a new Artisan command
 make:controller      Create a new controller class
 make:event           Create a new event class
+make:exception       Create a new custom exception class
+make:factory         Create a new model factory
 make:job             Create a new job class
 make:listener        Create a new event listener class
 make:mail            Create a new email class
@@ -44,11 +47,13 @@ make:pipe            Create a new pipe class
 make:policy          Create a new policy class
 make:provider        Create a new service provider class
 make:request         Create a new form request class
+make:resource        Create a new resource
 make:seeder          Create a new seeder class
 make:test            Create a new test class
-make:cast            Create a new cast class
 
 notifications:table  Create a migration for the notifications table
+
+schema:dump          Dump the given database schema
 ```
 
 ## Additional Useful Command
@@ -65,7 +70,7 @@ route:list        Display all registered routes.
 
 ## Tinker `include` Argument Usage
 
-`php artisan tinker path/to/tinker/script.php` 
+`php artisan tinker path/to/tinker/script.php`
 
 script.php example:
 ```

--- a/src/LumenGenerator/Console/DumpCommand.php
+++ b/src/LumenGenerator/Console/DumpCommand.php
@@ -1,0 +1,83 @@
+<?php
+namespace Flipbox\LumenGenerator\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Events\SchemaDumped;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Config;
+
+class DumpCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'schema:dump
+                {--database= : The database connection to use}
+                {--path= : The path where the schema dump file should be stored}
+                {--prune : Delete all existing migration files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Dump the given database schema';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
+    {
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $this->schemaState($connection)->dump(
+            $connection, $path = $this->path($connection)
+        );
+
+        $dispatcher->dispatch(new SchemaDumped($connection, $path));
+
+        $this->info('Database schema dumped successfully.');
+
+        if ($this->option('prune')) {
+            (new Filesystem)->deleteDirectory(
+                database_path('migrations'), $preserve = false
+            );
+
+            $this->info('Migrations pruned successfully.');
+        }
+    }
+
+    /**
+     * Create a schema state instance for the given connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return mixed
+     */
+    protected function schemaState(Connection $connection)
+    {
+        return $connection->getSchemaState()
+                ->withMigrationTable(Config::get('database.migrations', 'migrations'))
+                ->handleOutputUsing(function ($type, $buffer) {
+                    $this->output->write($buffer);
+                });
+    }
+
+    /**
+     * Get the path that the dump should be written to.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     */
+    protected function path(Connection $connection)
+    {
+        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.dump'), function ($path) {
+            (new Filesystem)->ensureDirectoryExists(dirname($path));
+        });
+    }
+}

--- a/src/LumenGenerator/LumenGeneratorServiceProvider.php
+++ b/src/LumenGenerator/LumenGeneratorServiceProvider.php
@@ -53,6 +53,7 @@ class LumenGeneratorServiceProvider extends ServiceProvider
         'NotificationMake' => 'command.notification.make',
         'NotificationTable' => 'command.notification.table',
         'ChannelMake' => 'command.channel.make',
+        'SchemaDump' => 'command.schema.dump',
     ];
 
     /**
@@ -341,6 +342,16 @@ class LumenGeneratorServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.channel.make', function ($app) {
             return new Console\ChannelMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     */
+    protected function registerSchemaDumpCommand()
+    {
+        $this->app->singleton('command.schema.dump', function () {
+            return new Console\DumpCommand();
         });
     }
 


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
It adds the `schema:dump` command (issue: https://github.com/flipboxstudio/lumen-generator/issues/94).

🔴 NOTE: You must have the component `illuminate/database` using the version >=v8.12.0 (because of [this change](https://github.com/illuminate/database/commit/23e82b209bf74a1c8211530d74a93bc292d87c4b))

How should this be manually tested?
-----------------------------------
1. Add the fork to your `composer.json` file:

```json
    "require": {
        "php": "^7.3|^8.0",
        "laravel/lumen-framework": "^8.0",
        "flipbox/lumen-generator": "dev-feature_add_schema_dump_command"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/jorgemudry/lumen-generator"
        }
    ]
```

2. Install the package:

```bash
$ composer update flipbox/lumen-generator;
```

3. Use the `schema:dump` command:

```bash
$ php artisan schema:dump
```

4. You should end up with a `your-connection-name-schema.dump` file in your `database/schema` directory.

Any background context you want to provide?
-------------------------------------------
N/A
 
Any extra info?
---------------
![anne](https://media4.giphy.com/media/kv5fbxHVAEOjrHeCLk/giphy.gif)