### PR TITLE
Add a package suggestion into the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "psr-4": {
             "Flipbox\\LumenGenerator\\": "src/LumenGenerator/"
         }
+    },
+    "suggest": {
+        "anik/form-request": "Required to use form request in Lumen."
     }
 }


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
It adds a new package suggestion into the `composer.json` file.

How should this be manually tested?
-----------------------------------
1. Install the package:

```bash
$ composer require flipbox/lumen-generator:dev-add_package_suggestion
```

2. You should see the suggested package (if you are using composer 2.0, you need to run `composer suggests` in order to see the suggestions).

Any background context you want to provide?
-------------------------------------------
This library has a `make:request` command that generates a form request class. That class depends on [this library](https://github.com/ssi-anik/form-request) (mainly because Lumen does not support form requests out of the box). That why the suggestion was added.

Any extra info?
---------------
![axel](https://i.pinimg.com/originals/7d/dc/1c/7ddc1c76be2ade63dbe5178d97eca181.gif)
