### PR TITLE
Add support for Lumen 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "A Lumen Generator You Are Missing",
     "type": "library",
     "require": {
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^8.17",
-        "illuminate/console": "^5.5|^6.0|^7.0|^8.0|^8.17",
-        "illuminate/filesystem": "^5.5|^6.0|^7.0|^8.0|^8.17",
-        "symfony/var-dumper": "^4.2|^4.3|^5.0|^5.1|^5.2",
-        "psy/psysh": "0.9.*|0.10.*",
-        "classpreloader/classpreloader": "^3.0|^4.0"
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^8.17|^9.0",
+        "illuminate/console": "^5.5|^6.0|^7.0|^8.0|^8.17|^9.0",
+        "illuminate/filesystem": "^5.5|^6.0|^7.0|^8.0|^8.17|^9.0",
+        "symfony/var-dumper": "^4.2|^4.3|^5.0|^5.1|^5.2|^6.0",
+        "psy/psysh": "0.9.*|0.10.*|0.11.*",
+        "classpreloader/classpreloader": "^3.0|^4.0|^4.2"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
It solves [this issue](https://github.com/flipboxstudio/lumen-generator/issues/114) by adding support for Lumen 9.x.

How should this be manually tested?
-----------------------------------
1. Get a clean installation of Lumen 9.x:
```bash
composer create-project --prefer-dist laravel/lumen lumen
```
2. Require the library: 
```bash
composer require flipbox/lumen-generator:dev-add_lumen_9_support
```
3. You should be able to install the library without any errors.

Any background context you want to provide?
-------------------------------------------
I'm creating this PR because the suggestions made [here](https://github.com/flipboxstudio/lumen-generator/pull/115) were never applied.

Any extra info?
---------------
![mj](https://movingimage.us/wp-content/uploads/2020/10/michael_jackson_eating_popcorn-550x238-detail-main-2.gif)